### PR TITLE
Add pg-upgrade subcommand

### DIFF
--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 	"log"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 )
 
 // Vars for tracking the list of Ghostwriter images
@@ -450,4 +453,40 @@ func RunDockerComposeRestore(yaml string, restore string) {
 	if backupErr != nil {
 		log.Fatalf("Error trying to restore %s with %s: %v\n", restore, yaml, backupErr)
 	}
+}
+
+// Gets the major version number of the PostgreSQL installation
+func PostgresVersionInstalled(
+	yaml string,
+) int {
+	out, err := RunBasicCmd("docker", []string{"compose", "-f", yaml, "run", "--rm", "postgres", "psql", "--version"})
+	if err != nil {
+		log.Fatalf("Error trying to get postgresql server version: %v\n", err)
+	}
+
+	match := regexp.MustCompile(`(\d+)\.\d+`).FindStringSubmatch(out)
+	if len(match) == 0 {
+		log.Fatalf("Could not find version in string %v", out)
+	}
+
+	majorVersion, err := strconv.Atoi(match[1])
+	if err != nil {
+		log.Fatalf("Could not parse installed Postgres version of %v: %v", match[1], err)
+	}
+	return majorVersion
+}
+
+// Gets the major version number of the PostgreSQL data. If different from the installation version, an upgrade is needed.
+func PostgresVersionForData(
+	yaml string,
+) int {
+	out, err := RunBasicCmd("docker", []string{"compose", "-f", yaml, "run", "--rm", "postgres", "cat", "/var/lib/postgresql/data/PG_VERSION"})
+	if err != nil {
+		log.Fatalf("Error trying to get postgresql data version: %v\n", err)
+	}
+	majorVersion, err := strconv.Atoi(strings.TrimSpace(out))
+	if err != nil {
+		log.Fatalf("Error trying to parse postgresql data version string %v: %v\n", out, err)
+	}
+	return majorVersion
 }

--- a/cmd/internal/utils.go
+++ b/cmd/internal/utils.go
@@ -86,13 +86,9 @@ func RunBasicCmd(name string, args []string) (string, error) {
 	return output, err
 }
 
-// RunCmd executes a given command (“name“) with a list of arguments (“args“)
-// and return stdout and stderr buffers.
-func RunCmd(name string, args []string) error {
-	// If the command is ``docker``, prepend ``compose`` to the args
-	if name == "docker" {
-		args = append([]string{"compose"}, args...)
-	}
+// RunRawCmd executes a given command (“name“) with a list of arguments (“args“)
+// Does not convert docker to docker compose like `RunCmd` does.
+func RunRawCmd(name string, args ...string) error {
 	path, err := exec.LookPath(name)
 	if err != nil {
 		log.Fatalf("`%s` is not installed or not available in the current PATH variable", name)
@@ -104,8 +100,10 @@ func RunCmd(name string, args []string) error {
 	exePath := filepath.Dir(exe)
 	command := exec.Command(path, args...)
 	command.Dir = exePath
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
 
-	stdout, err := command.StdoutPipe()
+	/*stdout, err := command.StdoutPipe()
 	if err != nil {
 		log.Fatalf("Failed to get stdout pipe for running `%s`", name)
 	}
@@ -125,7 +123,7 @@ func RunCmd(name string, args []string) error {
 		for stderrScanner.Scan() {
 			fmt.Printf("%s\n", stderrScanner.Text())
 		}
-	}()
+	}()*/
 	err = command.Start()
 	if err != nil {
 		log.Fatalf("Error trying to start `%s`: %v\n", name, err)
@@ -136,6 +134,15 @@ func RunCmd(name string, args []string) error {
 		return err
 	}
 	return nil
+}
+
+// RunCmd executes a given command (“name“) with a list of arguments (“args“)
+func RunCmd(name string, args []string) error {
+	// If the command is ``docker``, prepend ``compose`` to the args
+	if name == "docker" {
+		args = append([]string{"compose"}, args...)
+	}
+	return RunRawCmd(name, args...)
 }
 
 // GetLocalGhostwriterVersion fetches the local Ghostwriter version from the “VERSION“ file.

--- a/cmd/pgUpgrade.go
+++ b/cmd/pgUpgrade.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	docker "github.com/GhostManager/Ghostwriter_CLI/cmd/internal"
+	"github.com/spf13/cobra"
+)
+
+// installCmd represents the install command
+var pgUpgradeCmd = &cobra.Command{
+	Use:   "pg-upgrade",
+	Short: "Upgrades the PostgreSQL database",
+	Long: `Upgrades the PostgreSQL version. A production
+environment is installed by default. Use the "--dev" flag to install a development environment.
+`,
+	Run: pgUpgrade,
+}
+
+func init() {
+	rootCmd.AddCommand(pgUpgradeCmd)
+}
+
+func pgUpgrade(cmd *cobra.Command, args []string) {
+	docker.EvaluateDockerComposeStatus()
+	yaml := ""
+	interfix := ""
+	if dev {
+		docker.SetDevMode()
+		yaml = "local.yml"
+		interfix = "local"
+	} else {
+		docker.SetProductionMode()
+		yaml = "production.yml"
+		interfix = "production"
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf("Upgrading PostgreSQL data; it is highly recommended that you make a backup before doing this!\n")
+	fmt.Print("Press enter to continue, or Ctrl+C to cancel\n")
+	reader.ReadString('\n')
+
+	docker.RunDockerComposeDown(yaml)
+
+	fmt.Println("[+] Building Postgres container")
+	docker.RunCmd("docker", []string{"-f", yaml, "build", "postgres"})
+
+	fmt.Println("[+] Getting versions")
+	serverVersion := docker.PostgresVersionInstalled(yaml)
+	dataVersion := docker.PostgresVersionForData(yaml)
+	if serverVersion == dataVersion {
+		fmt.Println("No PostgreSQL upgrade needed")
+		return
+	}
+	fmt.Printf("Upgrading PostgreSQL data from %d to %d\n", dataVersion, serverVersion)
+
+	fmt.Println("[+] Starting old Postgres database")
+	err := docker.RunRawCmd("docker", "run", "-d", "--rm",
+		"--name", "ghostwriter_postgres_upgrade",
+		"--volume", "ghostwriter_local_postgres_data:/var/lib/postgresql/data/",
+		"--network", "ghostwriter_default",
+		fmt.Sprintf("postgres:%d", dataVersion),
+	)
+	if err != nil {
+		log.Fatalf("Could not start old Postgres server: %v\n", err)
+	}
+
+	// Wait for it to start
+	time.Sleep(10 * time.Second)
+
+	// Run the backup
+	fmt.Println("[+] Backing up data")
+	err = docker.RunCmd("docker", []string{"-f", yaml, "run", "-T", "--rm",
+		"postgres",
+		"bash", "-o", "pipefail", "-euc",
+		`source /usr/local/bin/_sourced/constants.sh; PGPASSWORD="${POSTGRES_PASSWORD}" pg_dump -h ghostwriter_postgres_upgrade -U "${POSTGRES_USER}" "${POSTGRES_DB}" | gzip > "${BACKUP_DIR_PATH}/_ghostwriter_postgres_upgrade.sql.gz"`,
+	})
+	if err != nil {
+		fmt.Println("[+] Stopping old Postgres server")
+		stopErr := docker.RunRawCmd("docker", "stop", "ghostwriter_postgres_upgrade")
+		if stopErr != nil {
+			log.Printf("Could not stop old postgres server: %v\n", err)
+		}
+		log.Fatalf("Could not run backup: %v\n", err)
+	}
+
+	fmt.Println("[+] Stopping old Postgres server")
+	err = docker.RunRawCmd("docker", "stop", "ghostwriter_postgres_upgrade")
+	if err != nil {
+		log.Fatalf("Could not stop old postgres server: %v\n", err)
+	}
+
+	fmt.Println("[+] Removing old Postgres volume")
+	err = docker.RunRawCmd("docker", "volume", "rm", fmt.Sprintf("ghostwriter_%s_postgres_data", interfix))
+	if err != nil {
+		log.Fatalf("Could not delete old postgres db volume: %v\n", err)
+	}
+
+	fmt.Println("[+] Starting new Postgres container")
+	err = docker.RunCmd("docker", []string{"-f", yaml, "up", "-d", "postgres"})
+	if err != nil {
+		log.Fatalf("Could not start new postgresql database: %v\n", err)
+	}
+	// Wait for it to start
+	time.Sleep(10 * time.Second)
+
+	fmt.Println("[+] Restoring data")
+	err = docker.RunCmd("docker", []string{"-f", yaml, "run", "-T", "--rm",
+		"postgres",
+		"restore",
+		"_ghostwriter_postgres_upgrade.sql.gz",
+	})
+	if err != nil {
+		log.Fatalf("Could not start new postgresql database: %v\n", err)
+	}
+
+	fmt.Println("[+] All done")
+}


### PR DESCRIPTION
PostgreSQL's data requires an upgrade step when changing major versions, which requires both the old and new versions to be installed.

This automates upgrades the PostgreSQL data, by exporting the data using the data's version (detected from the volume), clearing the volume, then re-importing it with the version in the docker-compose file.

Requires https://github.com/GhostManager/Ghostwriter/pull/514 to work.