### PR TITLE
Add collab containers

### DIFF
--- a/cmd/internal/docker.go
+++ b/cmd/internal/docker.go
@@ -23,11 +23,13 @@ var (
 		"ghostwriter_production_django", "ghostwriter_production_nginx",
 		"ghostwriter_production_redis", "ghostwriter_production_postgres",
 		"ghostwriter_production_graphql", "ghostwriter_production_queue",
+		"ghostwriter_production_collab_server",
 	}
 	devImages = []string{
 		"ghostwriter_local_django", "ghostwriter_local_redis",
 		"ghostwriter_local_postgres", "ghostwriter_local_graphql",
-		"ghostwriter_local_queue",
+		"ghostwriter_local_queue", "ghostwriter_collab_server",
+		"ghostwriter_frontend",
 	}
 	// Default root command for Docker commands
 	dockerCmd = "docker"

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	docker "github.com/GhostManager/Ghostwriter_CLI/cmd/internal"
 	"github.com/spf13/cobra"
 )
@@ -14,12 +15,14 @@ var logsCmd = &cobra.Command{
 
 Valid names are:
 
+* collab
 * django
+* frontend (dev only)
+* graphql
 * nginx
 * postgres
-* redis
-* graphql
-* queue`,
+* queue
+* redis`,
 	Args: cobra.ExactArgs(1),
 	Run:  readLogs,
 }


### PR DESCRIPTION
Now visible in `running`, `logs`, etc.

Requires https://github.com/GhostManager/Ghostwriter/pull/652