### PR TITLE
Change default healthcheck_disk_usage_max to expected 90

### DIFF
--- a/cmd/internal/env.go
+++ b/cmd/internal/env.go
@@ -110,7 +110,7 @@ func setGhostwriterConfigDefaultValues() {
 	ghostEnv.SetDefault("hasura_graphql_server_port", 8080)
 
 	// Docker & Django health check configuration
-	ghostEnv.SetDefault("healthcheck_disk_usage_max", 3)
+	ghostEnv.SetDefault("healthcheck_disk_usage_max", 90)
 	ghostEnv.SetDefault("healthcheck_interval", "300s")
 	ghostEnv.SetDefault("healthcheck_mem_min", 100)
 	ghostEnv.SetDefault("healthcheck_retries", 3)


### PR DESCRIPTION
This sets the health check DISK_USAGE_MAX to the expected 90% to resolve issues identified in #17.

